### PR TITLE
Fix the gem description to not be so superfluous

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ require 'jeweler'
 Jeweler::Tasks.new do |s|
   s.name        = 'tumblargh'
   s.summary     = 'Groan-less Tumblr theme development.'
-  s.description = `cat README.md`
+  s.description = "If you've ever had to build a Tumblr theme, you've probably cried out in pain while tweaking locally, copying, pasting into the theme editor, saving, switching tabs and finally refreshing and waiting for your tesing blog to reload. Tumblargh aims to reduce suffering involved with building a theme by offering a way to fully develop, lint and test Tumblr themes locally, with real posts from any existing Tumblog."
   s.authors     = ['Jason Webster']
   s.email       = 'jason@metalabdesign.com'
   s.homepage    = 'http://github.com/jasonwebster/tumblargh'


### PR DESCRIPTION
Your rubygems page is a bit of an eyesore, with the description field being too long: https://rubygems.org/gems/tumblargh

This change updates that.

Also, I recommend you drop the use of Jeweler and [use the gemspec](http://yehudakatz.com/2010/04/02/using-gemspecs-as-intended/) instead. :)
