### PR TITLE
Added new  {TagsAsClasses} method for Posts 

### DIFF
--- a/lib/tumblargh/renderer/blocks/posts.rb
+++ b/lib/tumblargh/renderer/blocks/posts.rb
@@ -11,6 +11,7 @@ module Tumblargh
         contextual_tag :post_id, :id
         contextual_tag :post_type, :type
         contextual_tag :title
+        contextual_tag :tags_as_classes
         contextual_tag :caption
 
         def permalink

--- a/lib/tumblargh/resource/post.rb
+++ b/lib/tumblargh/resource/post.rb
@@ -66,7 +66,7 @@ module Tumblargh
       end
 
       def tags_as_classes
-        @tags.collect { |tag| tag.name.downcase.underscore } if @tags.any?
+        @tags.collect { |tag| tag.name.downcase.underscore } if @tags and @tags.any?
       end
 
     end

--- a/lib/tumblargh/resource/post.rb
+++ b/lib/tumblargh/resource/post.rb
@@ -66,7 +66,9 @@ module Tumblargh
       end
 
       def tags_as_classes
-        tags.collect { |tag| tag.name.underscore }.join(' ') if tags and tags.any?
+        tags.collect { |tag| 
+          tag.name.titlecase.gsub(/\s+/, '').underscore.downcase 
+        }.join(' ') if tags and tags.any?
       end
 
     end

--- a/lib/tumblargh/resource/post.rb
+++ b/lib/tumblargh/resource/post.rb
@@ -65,6 +65,10 @@ module Tumblargh
         @photos ||= (@attributes[:photos] || []).map { |p| Photo.new(p) }
       end
 
+      def tags_as_classes
+        @tags.collect { |tag| tag.name.downcase.underscore } if @tags.any?
+      end
+
     end
 
   end

--- a/lib/tumblargh/resource/post.rb
+++ b/lib/tumblargh/resource/post.rb
@@ -66,7 +66,7 @@ module Tumblargh
       end
 
       def tags_as_classes
-        @tags.collect { |tag| tag.name.downcase.underscore } if @tags and @tags.any?
+        tags.collect { |tag| tag.name.underscore }.join(' ') if tags and tags.any?
       end
 
     end

--- a/spec/renderer/blocks/posts_spec.rb
+++ b/spec/renderer/blocks/posts_spec.rb
@@ -13,5 +13,4 @@ describe Tumblargh::Renderer::Blocks::Posts do
     result = Tumblargh.render_html(theme, @json)
     result.count("!").should eql @json[:posts].size
   end
-
 end

--- a/spec/resource/post_spec.rb
+++ b/spec/resource/post_spec.rb
@@ -33,6 +33,15 @@ describe Tumblargh::Resource::Post do
     end
   end
 
+  it "should give the tags as class names" do
+    @posts.each do |post|
+      tags = post.tags_as_classes
+
+      if post.tags.any?
+        post.tags.collect { |t| t.name.downcase.underscore }.join(" ").should == tags
+      end
+    end
+  end
 
 
 end

--- a/spec/resource/post_spec.rb
+++ b/spec/resource/post_spec.rb
@@ -38,7 +38,9 @@ describe Tumblargh::Resource::Post do
       tags = post.tags_as_classes
 
       if post.tags.any?
-        post.tags.collect { |t| t.name.downcase.underscore }.join(" ").should == tags
+        post.tags.collect { |t| 
+          t.name.titlecase.gsub(/\s+/, '').underscore.downcase 
+        }.join(" ").should == tags
       end
     end
   end


### PR DESCRIPTION
I noticed that there wasn't an implementation for TagsAsClasses, which is a tag on Posts (http://www.tumblr.com/docs/en/custom_themes#posts) so I added a simple implementation and some tests for it.

Sorry for the messyness of these commits, had to fiddle with it a bit to get it all working!

Thanks for your awesome work on this gem. Was a real help to me.
