### PR TITLE
Support for Block arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master
+
+- Block arguments, such as `{block:JumpPagination length="5"}` are now supported
+
 ## 0.2.0
 
 - Middlman 3.0 support

--- a/lib/tumblargh/grammar.rb
+++ b/lib/tumblargh/grammar.rb
@@ -134,6 +134,10 @@ module Tumblr
   end
 
   module BlockStart0
+    def block_name
+      elements[1]
+    end
+
   end
 
   def _nt_block_start
@@ -157,44 +161,43 @@ module Tumblr
     end
     s0 << r1
     if r1
-      s2, i2 = [], index
-      loop do
-        if has_terminal?('\G[^\\s}:;]', true, index)
-          r3 = true
-          @index += 1
-        else
-          r3 = nil
-        end
-        if r3
-          s2 << r3
-        else
-          break
-        end
-      end
-      if s2.empty?
-        @index = i2
-        r2 = nil
-      else
-        r2 = instantiate_node(SyntaxNode,input, i2...index, s2)
-      end
+      r2 = _nt_block_name
       s0 << r2
       if r2
-        if has_terminal?('}', false, index)
-          r4 = instantiate_node(SyntaxNode,input, index...(index + 1))
-          @index += 1
-        else
-          terminal_parse_failure('}')
-          r4 = nil
-        end
-        s0 << r4
+        r4 = _nt_space
         if r4
-          r6 = _nt_space
+          r3 = r4
+        else
+          r3 = instantiate_node(SyntaxNode,input, index...index)
+        end
+        s0 << r3
+        if r3
+          r6 = _nt_block_arguments
           if r6
             r5 = r6
           else
             r5 = instantiate_node(SyntaxNode,input, index...index)
           end
           s0 << r5
+          if r5
+            if has_terminal?('}', false, index)
+              r7 = instantiate_node(SyntaxNode,input, index...(index + 1))
+              @index += 1
+            else
+              terminal_parse_failure('}')
+              r7 = nil
+            end
+            s0 << r7
+            if r7
+              r9 = _nt_space
+              if r9
+                r8 = r9
+              else
+                r8 = instantiate_node(SyntaxNode,input, index...index)
+              end
+              s0 << r8
+            end
+          end
         end
       end
     end
@@ -212,6 +215,10 @@ module Tumblr
   end
 
   module BlockEnd0
+    def block_name
+      elements[1]
+    end
+
   end
 
   def _nt_block_end
@@ -235,44 +242,25 @@ module Tumblr
     end
     s0 << r1
     if r1
-      s2, i2 = [], index
-      loop do
-        if has_terminal?('\G[^\\s}]', true, index)
-          r3 = true
-          @index += 1
-        else
-          r3 = nil
-        end
-        if r3
-          s2 << r3
-        else
-          break
-        end
-      end
-      if s2.empty?
-        @index = i2
-        r2 = nil
-      else
-        r2 = instantiate_node(SyntaxNode,input, i2...index, s2)
-      end
+      r2 = _nt_block_name
       s0 << r2
       if r2
         if has_terminal?('}', false, index)
-          r4 = instantiate_node(SyntaxNode,input, index...(index + 1))
+          r3 = instantiate_node(SyntaxNode,input, index...(index + 1))
           @index += 1
         else
           terminal_parse_failure('}')
-          r4 = nil
+          r3 = nil
         end
-        s0 << r4
-        if r4
-          r6 = _nt_space
-          if r6
-            r5 = r6
+        s0 << r3
+        if r3
+          r5 = _nt_space
+          if r5
+            r4 = r5
           else
-            r5 = instantiate_node(SyntaxNode,input, index...index)
+            r4 = instantiate_node(SyntaxNode,input, index...index)
           end
-          s0 << r5
+          s0 << r4
         end
       end
     end
@@ -285,6 +273,198 @@ module Tumblr
     end
 
     node_cache[:block_end][start_index] = r0
+
+    r0
+  end
+
+  def _nt_block_name
+    start_index = index
+    if node_cache[:block_name].has_key?(index)
+      cached = node_cache[:block_name][index]
+      if cached
+        cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+        @index = cached.interval.end
+      end
+      return cached
+    end
+
+    s0, i0 = [], index
+    loop do
+      if has_terminal?('\G[^\\s}:;]', true, index)
+        r1 = true
+        @index += 1
+      else
+        r1 = nil
+      end
+      if r1
+        s0 << r1
+      else
+        break
+      end
+    end
+    if s0.empty?
+      @index = i0
+      r0 = nil
+    else
+      r0 = instantiate_node(SyntaxNode,input, i0...index, s0)
+    end
+
+    node_cache[:block_name][start_index] = r0
+
+    r0
+  end
+
+  def _nt_block_arguments
+    start_index = index
+    if node_cache[:block_arguments].has_key?(index)
+      cached = node_cache[:block_arguments][index]
+      if cached
+        cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+        @index = cached.interval.end
+      end
+      return cached
+    end
+
+    s0, i0 = [], index
+    loop do
+      r1 = _nt_block_argument
+      if r1
+        s0 << r1
+      else
+        break
+      end
+    end
+    if s0.empty?
+      @index = i0
+      r0 = nil
+    else
+      r0 = instantiate_node(SyntaxNode,input, i0...index, s0)
+    end
+
+    node_cache[:block_arguments][start_index] = r0
+
+    r0
+  end
+
+  module BlockArgument0
+  end
+
+  module BlockArgument1
+  end
+
+  def _nt_block_argument
+    start_index = index
+    if node_cache[:block_argument].has_key?(index)
+      cached = node_cache[:block_argument][index]
+      if cached
+        cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+        @index = cached.interval.end
+      end
+      return cached
+    end
+
+    i0, s0 = index, []
+    i1, s1 = index, []
+    s2, i2 = [], index
+    loop do
+      if has_terminal?('\G[a-zA-Z0-9]', true, index)
+        r3 = true
+        @index += 1
+      else
+        r3 = nil
+      end
+      if r3
+        s2 << r3
+      else
+        break
+      end
+    end
+    if s2.empty?
+      @index = i2
+      r2 = nil
+    else
+      r2 = instantiate_node(SyntaxNode,input, i2...index, s2)
+    end
+    s1 << r2
+    if r2
+      if has_terminal?('=', false, index)
+        r4 = instantiate_node(SyntaxNode,input, index...(index + 1))
+        @index += 1
+      else
+        terminal_parse_failure('=')
+        r4 = nil
+      end
+      s1 << r4
+      if r4
+        if has_terminal?('"', false, index)
+          r5 = instantiate_node(SyntaxNode,input, index...(index + 1))
+          @index += 1
+        else
+          terminal_parse_failure('"')
+          r5 = nil
+        end
+        s1 << r5
+        if r5
+          s6, i6 = [], index
+          loop do
+            if has_terminal?('\G[a-zA-Z0-9]', true, index)
+              r7 = true
+              @index += 1
+            else
+              r7 = nil
+            end
+            if r7
+              s6 << r7
+            else
+              break
+            end
+          end
+          if s6.empty?
+            @index = i6
+            r6 = nil
+          else
+            r6 = instantiate_node(SyntaxNode,input, i6...index, s6)
+          end
+          s1 << r6
+          if r6
+            if has_terminal?('"', false, index)
+              r8 = instantiate_node(SyntaxNode,input, index...(index + 1))
+              @index += 1
+            else
+              terminal_parse_failure('"')
+              r8 = nil
+            end
+            s1 << r8
+          end
+        end
+      end
+    end
+    if s1.last
+      r1 = instantiate_node(SyntaxNode,input, i1...index, s1)
+      r1.extend(BlockArgument0)
+    else
+      @index = i1
+      r1 = nil
+    end
+    s0 << r1
+    if r1
+      r10 = _nt_space
+      if r10
+        r9 = r10
+      else
+        r9 = instantiate_node(SyntaxNode,input, index...index)
+      end
+      s0 << r9
+    end
+    if s0.last
+      r0 = instantiate_node(SyntaxNode,input, i0...index, s0)
+      r0.extend(BlockArgument1)
+    else
+      @index = i0
+      r0 = nil
+    end
+
+    node_cache[:block_argument][start_index] = r0
 
     r0
   end

--- a/lib/tumblargh/grammar.treetop
+++ b/lib/tumblargh/grammar.treetop
@@ -12,11 +12,23 @@ grammar Tumblr
   end
 
   rule block_start
-    '{block:' [^\s}:;]+ '}' space? <Tumblargh::Node::BlockStart>
+    '{block:' block_name space? block_arguments? '}' space? <Tumblargh::Node::BlockStart>
   end
 
   rule block_end
-    '{/block:' [^\s}]+ '}' space? <Tumblargh::Node::BlockEnd>
+    '{/block:' block_name '}' space? <Tumblargh::Node::BlockEnd>
+  end
+
+  rule block_name
+    [^\s}:;]+
+  end
+
+  rule block_arguments
+    block_argument+
+  end
+
+  rule block_argument
+    (([a-zA-Z0-9]+) '=' '"' ([a-zA-Z0-9]+) '"') space?
   end
 
   rule tag

--- a/lib/tumblargh/node/block.rb
+++ b/lib/tumblargh/node/block.rb
@@ -1,6 +1,5 @@
 module Tumblargh
   module Node
-
     class Block < Root
 
       def name
@@ -8,8 +7,12 @@ module Tumblargh
         elements.first.name
       end
 
+      def options
+        elements.first.options
+      end
+
       def to_tree
-        ary = [type, name]
+        ary = [type, name, options]
 
         # Second node is a Treetop SyntaxNode which holds
         # the rest of the block contents. Extra parse node
@@ -22,10 +25,9 @@ module Tumblargh
           end
         end
 
-        return ary
+        ary
       end
 
     end
-
   end
 end

--- a/lib/tumblargh/node/block_start.rb
+++ b/lib/tumblargh/node/block_start.rb
@@ -1,6 +1,5 @@
 module Tumblargh
   module Node
-
     class BlockStart < Base
 
       def name
@@ -8,15 +7,28 @@ module Tumblargh
         "#{str[0].upcase}#{str[1..str.size]}"
       end
 
+      def options
+        arguments = elements[3]
+        return {} if arguments.nil? || arguments.elements.nil?
+
+        arguments.elements.inject({}) do |memo, node|
+          nodes = node.elements.first.elements
+          k = nodes[0].text_value
+          v = nodes[3].text_value
+
+          memo[k] = v
+          memo
+        end
+      end
+
       def matching_end
         "{/block:#{name}}"
       end
 
       def to_tree
-        return [type, name]
+        return [type, name, options]
       end
 
     end
-
   end
 end

--- a/lib/tumblargh/parser.rb
+++ b/lib/tumblargh/parser.rb
@@ -3,6 +3,8 @@ require 'open-uri'
 require 'nokogiri'
 
 module Tumblargh
+  class ParserError < StandardError
+  end
 
   class Parser
     grammar_file = File.join(File.dirname(__FILE__), 'grammar')
@@ -56,10 +58,8 @@ module Tumblargh
     def parse
       @structure = @@parser.parse(html)
 
-      if(@structure.nil?)
-        puts @@parser.failure_reason
-        puts "#{@@parser.failure_line}:#{@@parser.failure_column}"
-        raise ParserError, "Parse error at offset: #{@@parser.index}"
+      if @structure.nil?
+        raise ParserError, @@parser.failure_reason
       end
 
       @tree = @structure.to_tree
@@ -77,7 +77,7 @@ module Tumblargh
 
         default = case type
         when "if"
-          default == "1" ? true : false
+          default == "1"
         else
           default
         end
@@ -89,8 +89,4 @@ module Tumblargh
       opts
     end
   end
-
-  class ParserError < StandardError
-  end
-
 end

--- a/lib/tumblargh/renderer.rb
+++ b/lib/tumblargh/renderer.rb
@@ -9,7 +9,7 @@ require 'tumblargh/renderer/tag'
 module Tumblargh
   module Renderer
 
-    def self.factory(node, context)
+    def self.factory(node, context, options = {})
       args = []
       base = node.first.to_s
 
@@ -35,7 +35,7 @@ module Tumblargh
       klass_name = "Tumblargh::Renderer::#{base}"
       klass = klass_name.constantize
 
-      klass.new(node, context, *args)
+      klass.new(node, context, options, *args)
     end
 
   end

--- a/lib/tumblargh/renderer/base.rb
+++ b/lib/tumblargh/renderer/base.rb
@@ -1,15 +1,14 @@
 module Tumblargh
   module Renderer
-
     class Base
 
       class << self
 
         # Define a simple tag on the block.
-        # Name being tag name, and optionally the  attibute/method to call 
+        # Name being tag name, and optionally the  attibute/method to call
         # on the context. If the second argument is left off, it'll just use the tag name.
         def contextual_tag(name, attribute=nil)
-          class_eval do 
+          class_eval do
             define_method name do
               context.send(attribute || name)
             end
@@ -18,12 +17,15 @@ module Tumblargh
 
       end
 
-      attr_reader :node
+      attr_reader :node, :options
       attr_accessor :context
 
-      def initialize(node, context)
+      alias_method :config, :options # Backwards compatibility with old Document rendere
+
+      def initialize(node, context, options = {})
         @node = node
         @context = context
+        @options = options.with_indifferent_access
       end
 
       def context_post

--- a/lib/tumblargh/renderer/blocks.rb
+++ b/lib/tumblargh/renderer/blocks.rb
@@ -91,9 +91,9 @@ module Tumblargh
       class Boolean < Base
         attr_reader :variable
 
-        def initialize(node, context, *args)
+        def initialize(node, context, options = {}, *args)
           @variable = args[0]
-          super(node, context)
+          super(node, context, options)
         end
 
         def should_render?
@@ -120,7 +120,7 @@ module Tumblargh
         end
       end
 
-      # Identical to {PostTitle}, but will automatically generate a summary 
+      # Identical to {PostTitle}, but will automatically generate a summary
       # if a title doesn't exist.
       class PostSummary < PostTitle
         def post_summary

--- a/lib/tumblargh/renderer/blocks/base.rb
+++ b/lib/tumblargh/renderer/blocks/base.rb
@@ -22,10 +22,10 @@ module Tumblargh
         def render
           return '' unless should_render?
 
-          sig, type, *nodes = node
+          _, type, options, *nodes = node
 
           res = nodes.map do |n|
-            Renderer.factory(n, self).render
+            Renderer.factory(n, self, options).render
           end
 
           " #{res.join('')} "

--- a/lib/tumblargh/renderer/document.rb
+++ b/lib/tumblargh/renderer/document.rb
@@ -1,18 +1,10 @@
- module Tumblargh
+module Tumblargh
   module Renderer
-
     class Document < Base
-
-      attr_accessor :config
-
-      def initialize(node, context, config)
-        @config = config.with_indifferent_access
-        super(node, context)
-      end
 
       # Are we rendering a permalink page?
       def permalink?
-        @config[:permalink] == true
+        options[:permalink] == true
       end
 
       # TAGS ----------
@@ -20,6 +12,7 @@
       contextual_tag :description
 
       def meta_description
+        strip_html(description)
         strip_html(description)
       end
 
@@ -32,7 +25,7 @@
         "#{context.url}rss"
       end
 
-      # Appearance options 
+      # Appearance options
       # http://www.tumblr.com/docs/en/custom_themes#appearance-options
       def color(key)
         custom_value_for_type :color, key

--- a/spec/fixtures/themes/tumblr-boilerplate.html
+++ b/spec/fixtures/themes/tumblr-boilerplate.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="{block:English}en{/block:English}{block:French}fr{/block:French}{block:German}de{/block:German}{block:Japanese}ja{/block:Japanese}{block:Italian}it{/block:Italian}{block:Spanish}es{/block:Spanish}{block:Polish}pl{/block:Polish}">
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+	<meta name="viewport" content="width=device-width">
+	<title>{Title}{block:PostSummary} &mdash; {PostSummary}{/block:PostSummary}</title>
+	{block:Description}<meta name="description" content="{MetaDescription}">{/block:Description}
+
+	<link rel="apple-touch-icon" href="{PortraitURL-128}">
+	<link rel="shortcut icon" href="{Favicon}">
+	<link rel="alternate" type="application/rss+xml" href="{RSS}">
+	<!--Normalize 2.1.0 CSS-->
+	<link rel="stylesheet" href="http://static.tumblr.com/cqczc5x/kYdmihjuj/normalize.css" type="text/css" media="all">
+	<style type="text/css">
+
+		img, video, object, embed {
+			max-width: 100%;
+			height: auto !important;
+		}
+
+		.clearfix {zoom:1;}
+		.clearfix:before, .clearfix:after {
+		  content: "\0020";
+		  display: block;
+		  height: 0;
+		  overflow: hidden; }
+		.clearfix:after {clear: both;}
+
+		/*Tumblr inherited */
+		iframe#tumblr_controls {}
+		.search_query {}
+		.read_more_container a {}
+
+	</style>
+	<!--[if IE]><script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+</head>
+<body>
+	<header id="header">
+		<h1 id="logo"><a href="/">{Title}</a></h1>
+		{block:Description}<div class="description">{Description}</div>{/block:Description}
+		<ul id="nav">
+			{block:HasPages}{block:Pages}<li><a href="{URL}">{Label}</a></li>{/block:Pages}{/block:HasPages}
+			<li><a href="/archive">{lang:Archive}</a></li>
+			{block:AskEnabled}<li><a href="/ask">{AskLabel}</a></li>{/block:AskEnabled}
+		</ul>
+		<form id="search" action="/search" method="get">
+			<input type="text" placeholder="{lang:Search}" name="q" value="{SearchQuery}">
+			<input type="submit" value="{lang:Search}">
+		</form>
+	</header>
+	<section class="content">
+		{block:SearchPage}
+		<div class="result">
+			<p>{lang:Found SearchResultCount results for SearchQuery 2}</p>
+			{block:NoSearchResults}<p>{lang:No results for SearchQuery 2}</p>{/block:NoSearchResults}
+		</div>
+		{/block:SearchPage}
+		{block:TagPage}<div class="result"><p>{lang:TagResultCount posts tagged Tag 3}</p></div>{/block:TagPage}
+
+		{block:Posts}
+		<article class="post {TagsAsClasses}">
+			{block:Date}
+			{block:NewDayDate}<p>{DayOfWeek}, {Month} {DayOfMonth}, {Year}</p>{/block:NewDayDate}
+			{block:SameDayDate}<p>{DayOfWeek}, {Month} {DayOfMonth}, {Year}</p>{/block:SameDayDate}
+			{/block:Date}
+			{block:Text}
+			<div class="text">
+				{block:Title}<h3>{Title}</h3>{/block:Title}
+				{Body}
+			</div>
+			{/block:Text}
+			{block:Quote}
+			<div class="quote">
+				<blockquote class="words {Length}">&#8220;{Quote}&#8221;</blockquote>
+				{block:Source}<p class="source">&mdash; {Source}</p>{/block:Source}
+			</div>
+			{/block:Quote}
+			{block:Link}
+			<div class="link">
+				<h3><a href="{URL}" {Target}>{Name}</a></h3>
+				{block:Description}<div class="caption">{Description}</div>{/block:Description}
+			</div>
+			{/block:Link}
+			{block:Video}
+			<div class="video">
+				{Video-500}
+				{block:Caption}<div class="caption">{Caption}</div>{/block:Caption}
+			</div>
+			{/block:Video}
+			{block:Audio}
+			<div class="audio">
+				{block:AlbumArt}<img src="{AlbumArtURL}" alt="">{/block:AlbumArt}
+				{AudioPlayerBlack}
+				{block:Caption}<div class="caption">{Caption}</div>{/block:Caption}
+			</div>
+			{/block:Audio}
+			{block:Photo}
+			<div class="photo">
+					{LinkOpenTag}<img src="{PhotoURL-HighRes}" alt="{PhotoAlt}"/>{LinkCloseTag}
+					{block:Caption}<div class="caption">{Caption}</div>{/block:Caption}
+			</div>
+			{/block:Photo}
+			{block:Photoset}
+			<div class="photoset">
+				{block:Photos}
+					<img src="{PhotoURL-HighRes}" alt="{PhotoAlt}"/>
+					{block:Caption}<div class="caption">{Caption}</div>{/block:Caption}
+			    {/block:Photos}
+				{block:Caption}<div class="caption">{Caption}</div>{/block:Caption}
+			</div>
+			{/block:Photoset}
+
+			{block:Panorama}
+			<div class="panorama">
+			    {LinkOpenTag}<img src="{PhotoURL-Panorama}" alt="{PhotoAlt}" />{LinkCloseTag}
+			    {block:Caption}<div class="caption">{Caption}</div>{/block:Caption}
+			</div>
+			{/block:Panorama}
+
+			{block:Chat}
+			<div class="chat">
+				{block:Title}<h3>{Title}</h3>{/block:Title}
+				<ul class="conversation">
+					{block:Lines}
+					<li class="line {Alt}">
+						{block:Label}<span class="person">{Label}</span>{/block:Label}
+						<span class="person-said">{Line}</span>
+					</li>
+					{/block:Lines}
+				</ul>
+			</div>
+			{/block:Chat}
+			{block:Answer}
+			<div class="answer">
+				<img src="{AskerPortraitURL-40}">
+				{Asker}
+				{Question}
+				{Answer}
+			</div>
+			{/block:Answer}
+			{block:IndexPage}<p><a href="{Permalink}" class="permalink">{lang:Permalink}</a></p>{/block:IndexPage}
+		</article>
+		{/block:Posts}
+
+		{block:PermalinkPagination}
+		<div class="pagination">
+			{block:PreviousPost}<a class="prev"href="{PreviousPost}">{lang:Previous post}</a>{/block:PreviousPost}
+			{block:NextPost}<a class="next" href="{NextPost}">{lang:Next post}</a>{/block:NextPost}
+		</div>
+		{/block:PermalinkPagination}
+
+		{block:Pagination}
+		<div class="pagination">
+			{block:PreviousPage}<a class="prev" href="{PreviousPage}">{lang:Previous}</a>{/block:PreviousPage}
+
+			{block:JumpPagination length="5"}
+				{block:CurrentPage}<span class="current-page">{PageNumber}</span>{/block:CurrentPage}
+				{block:JumpPage}<a class="jump-page" href="{URL}">{PageNumber}</a>{/block:JumpPage}
+			{/block:JumpPagination}
+
+			{block:NextPage}<a class="next" href="{NextPage}">{lang:Next}</a>{/block:NextPage}
+		</div>
+		{/block:Pagination}
+
+	</section><!--close content-->
+</body>
+</html>

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,52 +1,40 @@
-require 'spec_helper'
+require "spec_helper"
 
 
 describe Tumblargh::Parser do
-
-  before do
-    @parser = Tumblargh::Parser.new
-  end
-
-  it "should exist" do
-    defined?(Tumblargh::Parser).should be_true
-  end
+  subject { Tumblargh::Parser.new }
 
   describe "given invalid input" do
-
     it "should throw an error if there is an unclosed block" do
-      @parser.html = <<-eos
+      subject.html = <<-eos
       {block:Text}
         {block:Title}<h1>{Title}</h1>{block:Title}
         <p>{Body}</p>
       {/block:text}
       eos
 
-      lambda { @parser.tree }.should raise_error Tumblargh::ParserError
+      lambda { subject.tree }.should raise_error Tumblargh::ParserError
     end
-
   end
 
   describe "given something that kinda looks like a tag but isn't" do
-
     before do
-      @parser.html = "<div>{CustomCSS</div>"
+      subject.html = "<div>{CustomCSS</div>"
     end
 
     it "should NOT throw an error if there is a malformed tag" do
-      lambda { @parser.tree }.should_not raise_error Tumblargh::ParserError
+      lambda { subject.tree }.should_not raise_error Tumblargh::ParserError
     end
 
     it "should generate the following tree" do
-      @parser.tree.should == [[:Literal, "<div>"], [:Literal, "{"], [:Literal, "CustomCSS</div>"]]
+      subject.tree.should == [[:Literal, "<div>"], [:Literal, "{"], [:Literal, "CustomCSS</div>"]]
     end
-
   end
 
   describe "when given a bunch of css" do
-
     before do
       @input = <<-eos
-      .container{*zoom:1;margin:auto;width:960px;max-width:100%;position:relative}.container:after{content:"";display:table;clear:both}.dot-sprite,#clients .nav .dots li,#clients .nav .dots li.active,#fullscreen_nav .nav .dots li,#fullscreen_nav .nav .dots li.active{background:url('../images/dot-sa49b299bc4.png') no-repeat}body.index{min-width:1000px}body.fullscreen{overflow-x:hidden}#clients{height:461px;overflow:visible;background:#fff url('../images/homepage-clients-bg.png') repeat-x 0 0px}#clients .frame{width:958px;height:448px;margin:0 auto;position:relative;-moz-border-radius:7px;-webkit-border-radius:7px;-o-border-radius:7px;-ms-border-radius:7px;-khtml-border-radius:7px;border-radius:7px;-moz-box-shadow:#000 0px 1px 2px;-webkit-box-shadow:#000 0px 1px 2px;-o-box-shadow:#000 0px 1px 2px;box-shadow:#000 0px 1px 2px;background:#262626}
+      .container{*zoom:1;margin:auto;width:960px;max-width:100%;position:relative}.container:after{content:"";display:table;clear:both}.dot-sprite,#clients .nav .dots li,#clients .nav .dots li.active,#fullscreen_nav .nav .dots li,#fullscreen_nav .nav .dots li.active{background:url("../images/dot-sa49b299bc4.png") no-repeat}body.index{min-width:1000px}body.fullscreen{overflow-x:hidden}#clients{height:461px;overflow:visible;background:#fff url("../images/homepage-clients-bg.png") repeat-x 0 0px}#clients .frame{width:958px;height:448px;margin:0 auto;position:relative;-moz-border-radius:7px;-webkit-border-radius:7px;-o-border-radius:7px;-ms-border-radius:7px;-khtml-border-radius:7px;border-radius:7px;-moz-box-shadow:#000 0px 1px 2px;-webkit-box-shadow:#000 0px 1px 2px;-o-box-shadow:#000 0px 1px 2px;box-shadow:#000 0px 1px 2px;background:#262626}
 
         #title a{
           text-decoration:none;
@@ -70,24 +58,21 @@ describe Tumblargh::Parser do
         #title b.right {right:-36px;}
       eos
 
-      @parser.html = @input
+      subject.html = @input
     end
 
     it "should NOT throw an error" do
-      lambda { @parser.tree }.should_not raise_error Tumblargh::ParserError
+      lambda { subject.tree }.should_not raise_error Tumblargh::ParserError
     end
 
     it "its output should match its input" do
-      @parser.to_s.should eql @input
+      subject.to_s.should eql @input
     end
-
   end
 
-
   describe "given a simple partial" do
-
     before do
-      @parser.html = <<-eos
+      subject.html = <<-eos
       {block:Text}
         {block:Title}<h1>{Title}</h1>{/block:Title}
         <p>{Body}</p>
@@ -96,48 +81,46 @@ describe Tumblargh::Parser do
     end
 
     it "should not contain any custom appearance options" do
-      @parser.options.empty?.should be_true
+      subject.options.empty?.should be_true
     end
 
     it "should contain the following tree" do
       expected = [
         [:Literal, "      "],
-        [:Block, "Text", 
-          [:Block, "Title", 
-            [:Literal, "<h1>"], 
-            [:Tag, "Title"], 
+        [:Block, "Text", {},
+          [:Block, "Title", {},
+            [:Literal, "<h1>"],
+            [:Tag, "Title"],
             [:Literal, "</h1>"]
-          ], 
-          [:Literal, "<p>"], 
-          [:Tag, "Body"], 
+          ],
+          [:Literal, "<p>"],
+          [:Tag, "Body"],
           [:Literal, "</p>\n      "]
         ]
       ]
 
       # Yes, Array.== Array is a deep value based comparison
-      @parser.tree.should == expected
+      subject.tree.should == expected
     end
-
   end
 
   describe "given jake's solstice theme" do
-
     before do
-      @parser.html = open(File.join(FIXTURE_PATH, 'themes', 'solstice.html')).read
+      subject.html = open(File.join(FIXTURE_PATH, "themes", "solstice.html")).read
     end
-    
+
     it "should contain the correct appearance options" do
-      @parser.options.should == {
+      subject.options.should == {
         "image" => {
           "background" => ""
-        }, 
+        },
         "if" => {
           "showpeopleifollow" => true,
-          "showmyportraitphoto" => true, 
-          "showvialinkswithrebloggedposts" => true, 
-          "useclassicpaging" => false, 
+          "showmyportraitphoto" => true,
+          "showvialinkswithrebloggedposts" => true,
+          "useclassicpaging" => false,
           "hidedisquscommentcountifzero" => false
-        }, 
+        },
         "text" => {
           "disqusshortname" => "",
           "googleanalyticsid" => ""
@@ -145,15 +128,71 @@ describe Tumblargh::Parser do
       }
     end
 
-    it "should contain exacty one 'posts' block" do
-      nodes = @parser.tree
-      matches = nodes.select do |n|
+    it "should contain exacty one Posts block" do
+      matches = subject.tree.select do |n|
         n[0] == :Block && n[1] == "Posts"
       end
 
       matches.size.should eql 1
     end
-    
   end
 
+  describe "block arguments" do
+    context "with a single argument" do
+      before do
+        subject.html = <<-eos
+        {block:JumpPagination length="5"}
+          {block:CurrentPage}<span class="current-page">{PageNumber}</span>{/block:CurrentPage}
+        {/block:JumpPagination}
+        eos
+      end
+
+      it "should contain the following tree" do
+        expected = [
+          [:Literal, "        "],
+          [:Block, "JumpPagination", { "length" => "5" },
+            [:Block, "CurrentPage", {},
+              [:Literal, "<span class=\"current-page\">"],
+              [:Tag, "PageNumber"],
+              [:Literal, "</span>"]
+            ]
+          ]
+        ]
+
+        subject.tree.should == expected
+      end
+    end
+
+    context "with multiple arguments" do
+      before do
+        subject.html = <<-eos
+        {block:Something length="5" offset="2" foo="bar"}{/block:Something}
+        eos
+      end
+
+      it "should contain the following tree" do
+        expected = [
+          [:Literal, "        "],
+          [:Block, "Something", { "length" => "5", "offset" => "2", "foo" => "bar" }]
+        ]
+
+        subject.tree.should == expected
+      end
+    end
+  end
+
+  describe "tumblr-boilerplate" do
+    before do
+      # https://github.com/davesantos/tumblr-boilerplate/master/tumblr.html
+      subject.html = open(File.join(FIXTURE_PATH, "themes", "tumblr-boilerplate.html")).read
+    end
+
+    it "should contain exacty one Posts block" do
+      matches = subject.tree.select do |n|
+        n[0] == :Block && n[1] == "Posts"
+      end
+
+      matches.size.should eql 1
+    end
+  end
 end


### PR DESCRIPTION
`{block:JumpPagination length="5"}` for example

Parser, AST and rendering loop now support block arguments. They are passed
into a block renderer as a hash of string keys and values.
