### PR TITLE
Moved alias line in order to avoid 'method not found' errors.

### DIFF
--- a/lib/middleman/extensions/tumblargh.rb
+++ b/lib/middleman/extensions/tumblargh.rb
@@ -27,12 +27,13 @@ module Middleman
   # up with as a workaround.
   module Sitemap
     class Store
-      alias_method :orig_find_resource_by_destination_path, :find_resource_by_destination_path
 
       def find_resource_by_destination_path(request_path)
         request_path = "/index.html" if request_path.match(/^\/post\//)
         orig_find_resource_by_destination_path(request_path)
       end
+
+      alias_method :orig_find_resource_by_destination_path, :find_resource_by_destination_path
     end
   end
 


### PR DESCRIPTION
Hi! I got this error everytime i tried running middleman

```
$ bundle exec middleman
/.../tumblargh/lib/middleman/extensions/tumblargh.rb:30:in `alias_method': undefined method `find_resource_by_destination_path' for class `Middleman::Sitemap::Store' (NameError)
```

Moving the alias line to the bottom solved this problem.
